### PR TITLE
Added the ability to explicitly calculate and cache a given range of holidays

### DIFF
--- a/lib/holidays.rb
+++ b/lib/holidays.rb
@@ -116,17 +116,7 @@ module Holidays
     end_date = end_date.new_offset(0) + end_date.offset if end_date.respond_to?(:new_offset)
 
     # get simple dates
-    if start_date.respond_to?(:to_date)
-      start_date = start_date.to_date 
-    else
-      start_date = Date.civil(start_date.year, start_date.mon, start_date.mday)
-    end 
-
-    if end_date.respond_to?(:to_date)
-      end_date = end_date.to_date
-    else
-      end_date = Date.civil(end_date.year, end_date.mon, end_date.mday)
-    end 
+    start_date, end_date = get_date(start_date), get_date(end_date)
 
     if range = @@cache_range[options]
       if range.begin < start_date && range.end > end_date
@@ -197,6 +187,7 @@ module Holidays
 
   # Allows a developer to explicitly calculate and cache holidays within a given period
   def self.cache_between(start_date, end_date, *options)
+    start_date, end_date = get_date(start_date), get_date(end_date)
     @@cache[options]       = between(start_date, end_date, *options)
     @@cache_range[options] = start_date..end_date
   end
@@ -333,6 +324,14 @@ private
     informal = options.delete(:informal) ? true : false
     regions = parse_regions(options)
     return regions, observed, informal
+  end
+
+  def self.get_date(date)
+    if date.respond_to?(:to_date)
+      date.to_date
+    else
+      Date.civil(date.year, date.mon, date.mday)
+    end
   end
 
   # Check regions against list of supported regions and return an array of 

--- a/test/test_holidays.rb
+++ b/test/test_holidays.rb
@@ -157,4 +157,19 @@ class HolidaysTests < Test::Unit::TestCase
       }
     }
   end
+
+  def test_caching
+    Holidays.cache_between(Date.civil(2008,3,21), Date.civil(2008,3,25), :ca, :informal)
+
+    # Test that cache has been set
+    cache_key = [:ca, :informal]
+    assert_equal Date.civil(2008,3,21), Holidays.cache_range[cache_key].begin
+    assert_equal Date.civil(2008,3,25), Holidays.cache_range[cache_key].end
+    assert_equal Date.civil(2008,3,21), Holidays.cache[cache_key].first[:date]
+    assert_equal Date.civil(2008,3,24), Holidays.cache[cache_key].last[:date]
+
+    # Test that correct results are returned outside the cache range, and with no caching
+    assert_equal 1, Holidays.on(Date.civil(2035,1,1), :ca, :informal).length
+    assert_equal 1, Holidays.on(Date.civil(2035,1,1), :us).length
+  end
 end


### PR DESCRIPTION
Hi there,

Our app does a lot of date calculations, and we previously had a hard-coded list of holidays. After switching to the `holidays` gem, we noticed that some of our requests were taking 30% longer because of many holiday calculations.

This pull request adds a simple `Hollidays.cache_between` method, so that we can calculate and cache a list of holidays when the app boots. For example, I've added this in an initializer:

```
Holidays.cache_between Time.now, 2.years.from_now, :us, :observed
```

Please let me know if you think there's a better way to do this.