### PR TITLE
added german city specific holiday for Augsburg

### DIFF
--- a/data/de.yaml
+++ b/data/de.yaml
@@ -38,6 +38,9 @@ months:
   - name: Mariä Himmelfahrt
     regions: [de_by, de_sl]
     mday: 15
+  - name: Friedensfest
+    regions: [de_by_aux]
+    mday: 8
   10: 
   - name: Tag der Deutschen Einheit
     regions: [de]


### PR DESCRIPTION
There exists a city-specific holiday for the town of Augsburg in Bavaria, Germany as described here http://www.kalenderpedia.de/feiertage/feiertage-bayern.html. It always is on the 8th of August. The IATA-Code for Augsburg is AUX. Therefore, I created a new region called de_by_aux and added the holiday to it. 