### PR TITLE
New Zealand public holidays mondayised

### DIFF
--- a/data/nz.yaml
+++ b/data/nz.yaml
@@ -46,6 +46,7 @@ months:
   - name: Waitangi Day
     regions: [nz]
     mday: 6
+    observed: to_monday_if_weekend
   3:
   - name: Otago Anniversary Day
     regions: [nz_ot]
@@ -59,6 +60,7 @@ months:
   - name: ANZAC Day
     regions: [nz]
     mday: 25
+    observed: to_monday_if_weekend
   6:
   - name: Queen's Birthday
     regions: [nz]

--- a/data/nz.yaml
+++ b/data/nz.yaml
@@ -119,6 +119,14 @@ tests: |
      Date.civil(2007,12,26) => 'Boxing Day'}.each do |date, name|
       assert_equal name, (Holidays.on(date, :nz, :informal)[0] || {})[:name]
     end
+    assert_equal 'ANZAC Day', Date.civil(2015, 4, 25).holidays(:nz)[0][:name]
+    assert_equal 'ANZAC Day', Date.civil(2015, 4, 27).holidays(:nz, :observed)[0][:name]
+    assert_equal 'ANZAC Day', Date.civil(2016, 4, 25).holidays(:nz)[0][:name]
+    assert_equal 'ANZAC Day', Date.civil(2016, 4, 25).holidays(:nz, :observed)[0][:name]
+    assert_equal 'Waitangi Day', Date.civil(2015, 2, 6).holidays(:nz)[0][:name]
+    assert_equal 'Waitangi Day', Date.civil(2015, 2, 6).holidays(:nz, :observed)[0][:name]
+    assert_equal 'Waitangi Day', Date.civil(2016, 2, 6).holidays(:nz)[0][:name]
+    assert_equal 'Waitangi Day', Date.civil(2016, 2, 8).holidays(:nz, :observed)[0][:name]
 methods:
   closest_monday: |
     def self.closest_monday(date)

--- a/lib/holidays/nz.rb
+++ b/lib/holidays/nz.rb
@@ -28,10 +28,10 @@ module Holidays
             {:mday => 29, :observed => lambda { |date| Holidays.closest_monday(date) }, :observed_id => "closest_monday", :name => "Auckland Anniversary Day", :regions => [:nz_ak]},
             {:mday => 29, :observed => lambda { |date| Holidays.closest_monday(date) }, :observed_id => "closest_monday", :name => "Northland Anniversary Day", :regions => [:nz_nl]}],
       2 => [{:mday => 1, :observed => lambda { |date| Holidays.closest_monday(date) }, :observed_id => "closest_monday", :name => "Nelson Anniversary Day", :regions => [:nz_ak]},
-            {:mday => 6, :name => "Waitangi Day", :regions => [:nz]}],
+            {:mday => 6, :observed => lambda { |date| Holidays.to_monday_if_weekend(date) }, :observed_id => "to_monday_if_weekend", :name => "Waitangi Day", :regions => [:nz]}],
       3 => [{:mday => 23, :observed => lambda { |date| Holidays.closest_monday(date) }, :observed_id => "closest_monday", :name => "Otago Anniversary Day", :regions => [:nz_ot]},
             {:wday => 1, :week => 2, :name => "Taranaki Anniversary Day", :regions => [:nz_ak]}],
-      4 => [{:mday => 25, :name => "ANZAC Day", :regions => [:nz]}],
+      4 => [{:mday => 25, :observed => lambda { |date| Holidays.to_monday_if_weekend(date) }, :observed_id => "to_monday_if_weekend", :name => "ANZAC Day", :regions => [:nz]}],
       6 => [{:wday => 1, :week => 1, :name => "Queen's Birthday", :regions => [:nz]}],
       9 => [{:wday => 1, :week => 4, :name => "Dominion Day", :regions => [:nz_sc]}],
       10 => [{:wday => 1, :week => 1, :observed => lambda { |date| Holidays.previous_friday(date) }, :observed_id => "previous_friday", :name => "Hawke's bay Anniversary Day", :regions => [:nz_hb]},
@@ -66,6 +66,7 @@ end
 def self.next_week(date)
   date + 7
 end
+
 
 
 end

--- a/test/defs/test_defs_nz.rb
+++ b/test/defs/test_defs_nz.rb
@@ -17,6 +17,14 @@ class NzDefinitionTests < Test::Unit::TestCase  # :nodoc:
  Date.civil(2007,12,26) => 'Boxing Day'}.each do |date, name|
   assert_equal name, (Holidays.on(date, :nz, :informal)[0] || {})[:name]
 end
+assert_equal 'ANZAC Day', Date.civil(2015, 4, 25).holidays(:nz)[0][:name]
+assert_equal 'ANZAC Day', Date.civil(2015, 4, 27).holidays(:nz, :observed)[0][:name]
+assert_equal 'ANZAC Day', Date.civil(2016, 4, 25).holidays(:nz)[0][:name]
+assert_equal 'ANZAC Day', Date.civil(2016, 4, 25).holidays(:nz, :observed)[0][:name]
+assert_equal 'Waitangi Day', Date.civil(2015, 2, 6).holidays(:nz)[0][:name]
+assert_equal 'Waitangi Day', Date.civil(2015, 2, 6).holidays(:nz, :observed)[0][:name]
+assert_equal 'Waitangi Day', Date.civil(2016, 2, 6).holidays(:nz)[0][:name]
+assert_equal 'Waitangi Day', Date.civil(2016, 2, 8).holidays(:nz, :observed)[0][:name]
 
   end
 end


### PR DESCRIPTION
NZ passed a bill in 2013 which makes the following Monday a public holiday if Anzac or Waitangi day occur on the weekend. [1]

[1] http://www.3news.co.nz/politics/extra-public-holidays-voted-in-2013041719