### PR TITLE
Update au.yaml

### DIFF
--- a/data/au.yaml
+++ b/data/au.yaml
@@ -52,7 +52,10 @@ months:
     function: march_pub_hol_sa(year)
   4: 
   - name: ANZAC Day
-    regions: [au]
+    regions: [au_nsw, au_vic, au_qld, au_nt, au_act, au_sa, au_tas]
+    mday: 25
+  - name: ANZAC Day
+    regions: [au_wa]
     mday: 25
     observed: to_monday_if_weekend
   5: 


### PR DESCRIPTION
(Australia) Anzac day holiday (April 25) - only WA observes the holiday on the following Monday if it falls on a weekend. http://www.theage.com.au/victoria/no-extra-public-holiday-for-anzac-day-2015-20140720-zv1ep.html