### PR TITLE
Fix Japanese non-Monday substitute holidays such as 2015-05-06

### DIFF
--- a/data/jp.yaml
+++ b/data/jp.yaml
@@ -9,6 +9,7 @@
 # CHANGES:
 #  2010-12-25: Initial version by Tatsuki Sugiura <sugi@nemui.org>
 #  2014-11-09: Added substitute holiday by Yoshiyuki Hirano <yoshiyuki.hirano@henteco-labs.com>
+#  2015-05-10: Non-Monday substitute holidays by Shuhei Kagawa <shuhei.kagawa@gmail.com>
 # 
 ---
 months:
@@ -57,6 +58,9 @@ months:
   - name: 振替休日
     regions: [jp]
     function: jp_substitute_holiday(year, 5, 3)
+  - name: 振替休日
+    regions: [jp]
+    function: jp_substitute_holiday(year, 5, 4)
   - name: 振替休日
     regions: [jp]
     function: jp_substitute_holiday(year, 5, 5)
@@ -165,7 +169,14 @@ methods:
   jp_substitute_holiday: |
     def self.jp_substitute_holiday(*date)
       date = date[0].kind_of?(Date) ? date.first : Date.civil(*date)
-      date.wday == 0 ? date+1 : nil
+      date.wday == 0 ? Holidays.jp_next_weekday(date+1) : nil
+    end
+  jp_next_weekday(date): |
+    def self.jp_next_weekday(date)
+      is_holiday = Holidays::JP.holidays_by_month[date.month].any? do |holiday|
+        holiday[:mday] == date.day
+      end
+      date.wday == 0 || is_holiday ? Holidays.jp_next_weekday(date+1) : date
     end
 tests: |
   {Date.civil(2008,1,1) => '元日', 
@@ -183,6 +194,9 @@ tests: |
    Date.civil(2010,3,22) => '振替休日',
    Date.civil(2008,11,24) => '振替休日',
    Date.civil(2012,1,2) => '振替休日',
+   Date.civil(2013,5,6) => '振替休日',
+   Date.civil(2014,5,6) => '振替休日',
+   Date.civil(2015,5,6) => '振替休日'
   }.each do |date, name|
      assert_equal name, (Holidays.on(date, :jp, :informal)[0] || {})[:name]
   end

--- a/lib/holidays/jp.rb
+++ b/lib/holidays/jp.rb
@@ -31,6 +31,7 @@ module Holidays
             {:mday => 4, :name => "みどりの日", :regions => [:jp]},
             {:mday => 5, :name => "こどもの日", :regions => [:jp]},
             {:function => lambda { |year| Holidays.jp_substitute_holiday(year, 5, 3) }, :function_id => "jp_substitute_holiday(year, 5, 3)", :name => "振替休日", :regions => [:jp]},
+            {:function => lambda { |year| Holidays.jp_substitute_holiday(year, 5, 4) }, :function_id => "jp_substitute_holiday(year, 5, 4)", :name => "振替休日", :regions => [:jp]},
             {:function => lambda { |year| Holidays.jp_substitute_holiday(year, 5, 5) }, :function_id => "jp_substitute_holiday(year, 5, 5)", :name => "振替休日", :regions => [:jp]}],
       7 => [{:wday => 1, :week => 3, :name => "海の日", :regions => [:jp]},
             {:function => lambda { |year| Holidays.jp_substitute_holiday(year, 7, Date.calculate_mday(year, 7, 3, 1)) }, :function_id => "jp_substitute_holiday(year, 7, Date.calculate_mday(year, 7, 3, 1))", :name => "振替休日", :regions => [:jp]}],
@@ -104,7 +105,15 @@ end
 
 def self.jp_substitute_holiday(*date)
   date = date[0].kind_of?(Date) ? date.first : Date.civil(*date)
-  date.wday == 0 ? date+1 : nil
+  date.wday == 0 ? Holidays.jp_next_weekday(date+1) : nil
+end
+
+
+def self.jp_next_weekday(date)
+  is_holiday = Holidays::JP.holidays_by_month[date.month].any? do |holiday|
+    holiday[:mday] == date.day
+  end
+  date.wday == 0 || is_holiday ? Holidays.jp_next_weekday(date+1) : date
 end
 
 

--- a/test/defs/test_defs_jp.rb
+++ b/test/defs/test_defs_jp.rb
@@ -22,6 +22,9 @@ class JpDefinitionTests < Test::Unit::TestCase  # :nodoc:
  Date.civil(2010,3,22) => '振替休日',
  Date.civil(2008,11,24) => '振替休日',
  Date.civil(2012,1,2) => '振替休日',
+ Date.civil(2013,5,6) => '振替休日',
+ Date.civil(2014,5,6) => '振替休日',
+ Date.civil(2015,5,6) => '振替休日'
 }.each do |date, name|
    assert_equal name, (Holidays.on(date, :jp, :informal)[0] || {})[:name]
 end


### PR DESCRIPTION
In Japan, we have sequential holidays in May and their substitute holidays can be Tuesday or Wednesday. For instance, in 2015:

- **May 3, Sun, Constitution Day**
- May 4, Mon, Greenery Day
- May 5, Tue, Children's Day
- **May 6, Wed, Substitute Holiday of Constitution Day**

This PR fixes the algorithm for substitution holiday to allow non-Monday substitute holidays in Japan.

Reference: [Wikipedia 振替休日](http://ja.wikipedia.org/wiki/%E6%8C%AF%E6%9B%BF%E4%BC%91%E6%97%A5#.E6.8C.AF.E6.9B.BF.E4.BC.91.E6.97.A5.E3.81.AE.E6.97.A5.E4.BB.98.E3.81.AE.E4.B8.80.E8.A6.A7) (Sorry, it's Japanese.)